### PR TITLE
Fix bug: Add 'shelljs' installation to setup script and include npm r…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
         "build:scripts": "node scripts/build-scripts.js",
         "build:scss": "node scripts/build-scss.js",
         "clean": "node scripts/clean.js",
-        "start": "npm run build && node scripts/start.js",
-        "start:debug": "npm run build && node scripts/start-debug.js"
+        "start": "npm run setup && node scripts/start.js",
+        "start:debug": "npm run build && node scripts/start-debug.js",
+        "setup": "npm install shelljs"
     },
     "description": "An HTML landing page template built with Bootstrap",
     "keywords": [


### PR DESCRIPTION
문제 : npm start시 Error: Cannot find module 'shelljs' 에러가 뜸
해결 : package.json 파일에 scripts에 "setup": "npm install shelljs" 를 추가한 뒤 start에 npm run setup을 추가.

=> 프로그램 실행시 자동으로 shelljs모듈을 설치하여 Error: Cannot find module 'shelljs 문제를 해결.