### PR TITLE
Remove build step, set up BrowserSync to watch CSS files, and add dark mode

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*!
 * Start Bootstrap - Landing Page v6.0.6 (https://startbootstrap.com/theme/landing-page)
-* Copyright 2013-2024 Start Bootstrap
+* Copyright 2013-2023 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-landing-page/blob/master/LICENSE)
 */
 /*!
@@ -90,7 +90,56 @@
     scroll-behavior: smooth;
   }
 }
+/* 다크 모드가 활성화된 상태에서의 스타일 */
+body.dark-mode {
+	background-color: #121212;        
+	color: #ffffff; /* 기본 글자 색상 */
+}
 
+/* 개별 요소에 대한 다크 모드 스타일 */
+body.dark-mode nav {
+	background-color: #121212 !important;
+}
+
+body.dark-mode section.testimonials.text-center.bg-light {
+	background-color: #121212 !important;
+}
+body.dark-mode section.features-icons.bg-light.text-center {
+	background-color: #121212 !important;
+}
+body.dark-mode footer {
+	background-color: #121212 !important;
+}
+
+body.dark-mode div {
+        background-color: #121212;
+	border-color: #444; /* 테두리 색상 */
+}
+body.dark-mode a {
+	color: white;
+}
+
+/* .row 클래스의 배경색을 없애기 */
+body.dark-mode [class^="row"] {
+    background-color: transparent !important;
+}
+body.dark-mode div.col-xl-6 {
+	background-color: transparent !important;
+}
+body.dark-mode div.text-center.text-white {
+	background-color: transparent !important;
+}
+body.dark-mode div.col {
+	background-color: transparent !important;
+	
+}
+body.dark-mode div.col-auto {
+	background-color: transparent !important;
+}
+body.dark-mode div.container.position-relative {
+	background-color: transparent !important;
+}
+body.dark-mode
 body {
   margin: 0;
   font-family: var(--bs-body-font-family);

--- a/dist/index.html
+++ b/dist/index.html
@@ -21,6 +21,7 @@
             <div class="container">
                 <a class="navbar-brand" href="#!">Start Bootstrap</a>
                 <a class="btn btn-primary" href="#signup">Sign Up</a>
+		<button id="toggle-dark-mode" class="btn btn-secondary">Dark Mode</button>
             </div>
         </nav>
         <!-- Masthead-->

--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -1,7 +1,35 @@
 /*!
 * Start Bootstrap - Landing Page v6.0.6 (https://startbootstrap.com/theme/landing-page)
-* Copyright 2013-2024 Start Bootstrap
+* Copyright 2013-2023 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-landing-page/blob/master/LICENSE)
 */
 // This file is intentionally blank
-// Use this file to add JavaScript to your project!
+// Use this file to add JavaScript to your project
+//
+//
+const toggleButton = document.getElementById('toggle-dark-mode');
+toggleButton.addEventListener('click', () => {
+	    // 다크 모드 토글
+     document.body.classList.toggle('dark-mode');  // body에 'dark-mode' 클래스 추가/제거
+
+         // 다크 모드 상태를 로컬 저장소에 저장
+             if (document.body.classList.contains('dark-mode')) {
+                     localStorage.setItem('theme', 'dark');
+                             toggleButton.textContent = 'Light Mode';  // 버튼 텍스트 변경
+                                 } else {
+                                         localStorage.setItem('theme', 'light');
+                                                 toggleButton.textContent = 'Dark Mode';  // 버튼 텍스트 변경
+                                                     }
+                                                   });
+
+                                                     // 페이지 로드 시 저장된 테마를 확인하고 적용
+                                                     window.addEventListener('load', () => {
+                                                         const savedTheme = localStorage.getItem('theme');
+                                                             if (savedTheme === 'dark') {
+                                                                     document.body.classList.add('dark-mode');
+                                                                             toggleButton.textContent = 'Light Mode';  // 저장된 테마가 다크 모드일 때 버튼 텍스트 변경
+                                                                                 } else {
+                                                                                         toggleButton.textContent = 'Dark Mode';  // 저장된 테마가 라이트 모드일 때 버튼 텍스트 변경
+                                                                                             }
+                                                                                             });
+                                                                                             

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -3,7 +3,7 @@ const upath = require('upath');
 
 const browserSyncPath = upath.resolve(upath.dirname(__filename), '../node_modules/.bin/browser-sync');
 
-concurrently([
+/*concurrently([
     { command: 'node scripts/sb-watch.js', name: 'SB_WATCH', prefixColor: 'bgBlue.bold' },
     { 
         command: `"${browserSyncPath}" --reload-delay 2000 --reload-debounce 2000 dist -w --no-online`,
@@ -14,7 +14,17 @@ concurrently([
     prefix: 'name',
     killOthers: ['failure', 'success'],
 }).then(success, failure);
-
+*/
+concurrently([
+	{
+		command: `"${browserSyncPath}" dist -w --files dist/**/*.css --no-online`,
+		name: 'SB_BROWSER_SYNC',
+		prefixColor: 'bgGreen.bold',
+	}
+], {
+	prefix: 'name',
+	killOthers: ['failure', 'success'],
+})
 function success() {
     console.log('Success');    
 }


### PR DESCRIPTION
1. package.json파일에 scripts에 start시 npm run build부분을 제거.
 - 불필요한 빌드 시간 절감: 개발 및 테스트 환경에서는 빌드가 필요 없는 경우가 많으므로 개발시 npm run build를 통해 매번 빌드를 진행하는 것은 불필요하게 시간을 소모하며 이는 개발 속도에 영향을 미친다.
 - 효율적인 개발 워크플로우: 빌드 과정이 없는 상태에서 직접 코드를 수정하고 실행할 수 있는 환경을 제공함으로써, 개발자가 더 빠르게 변경 사항을 반영하고 테스트할 수 있게 된다.
 - 작업 환경에 맞춘 최적화: 개발 환경에서는 빌드가 필요 없거나, 이미 다른 방식으로 자동화된 도구들이 빌드 과정을 처리할 수 있기에, 불필요한 빌드 과정은 제외하는 것이 효율적이다.

2.  Set up BrowserSync to watch CSS files in dist directory
기존 코드에서는 sb-watch.js파일을 이용하여 SCSS 파일을 감시하여 CSS 파일을 자동으로 생성하는 작업을 진행했다.
문제 : css파일에서 작업을 진행하고 저장한 뒤 npm start를 진행하면 sb-watch.js가 scss코드를 감시하여 css파일을 자동으로 생성하므로 수정했던 css코드가 scss파일을 컴파일하면서 덮어쓰여서 수정한 내용이 사라짐.
해결 : scss 파일에서 작업을 진행하거나 scss파일이 아닌 css파일을 감시하도록 수정한다.
=> 후자의 방법을 선택하여 진행

3. dark mode 추가
dist/css/styles.css : 다크모드에서 사용할 스타일을 추가
dist/js/scripts.js : 다크모드를 활성화/비활성화하는 버튼을 눌렀을 때 body에 dark-mode 클래스를 추가하거나 제거한다. 
이때 활성화할때 버튼의 텍스트는 dark mode, 비활성화 할때 버튼의 텍스트는 light mode로 변경되도록 설정한다.
사용자가 다크모드 상태를 유지하도록 로컬 스토리지(Local Storage)를 활용해 저장하며, 페이지 로드시 local storage에서 저장된 테마를 가져온다.
dist/index.html : <button id="toggle-dark-mode" class="btn btn-secondary">Dark Mode</button> 를 추가한다.